### PR TITLE
Use nullptr instead of NULL

### DIFF
--- a/linklist node concept.cpp
+++ b/linklist node concept.cpp
@@ -13,17 +13,17 @@ private:
 public:
     linked_list()
     {
-        head = NULL;
-        tail = NULL;
+        head = nullptr;
+        tail = nullptr;
     }
 
     void add_node()
     {
         tmp = new node;
       	cin>> tmp->data;
-        tmp->next = NULL;
+        tmp->next = nullptr;
 
-        if(head == NULL)
+        if(head == nullptr)
         {
             head = tmp;
             tail = tmp;
@@ -37,7 +37,7 @@ public:
     void print()
 	{
 		tmp=head;
-		while(tmp!=NULL)
+		while(tmp!=nullptr)
 		{
 			cout<<tmp->data;
 			tmp=tmp->next;


### PR DESCRIPTION
Before C++11, the constant ```NULL``` was used for null pointers. ```NULL``` is
simply defined as the constant 0, and this can cause problems when overloading functions. Let's understand it with an example

```
void func(char* str) {cout << "char* version" << endl;}
void func(int i) {cout << "int version" << endl;}
int main()
{
func(NULL);
return 0;
}
```


The ```main()``` function is calling ```func()``` with parameter ```NULL```, which is
supposed to be a null pointer constant. In other words, you are
expecting the ```char*``` version of ```func()``` to be called with a null pointer
as argument. However, since ```NULL``` is not a pointer, but identical to
the integer 0, the integer version of ```func()``` is called.

This problem is solved with the introduction of a real null pointer
constant, ```nullptr```. The following code calls the ```char*``` version:
```func(nullptr)```;